### PR TITLE
Implemented pop and len methods/tests

### DIFF
--- a/src/dsa/hashtable.py
+++ b/src/dsa/hashtable.py
@@ -132,4 +132,23 @@ class HashTable:
         for i, bucket in enumerate(self.array):
             s += f"Bucket {i}: {bucket}\n"
         return s
-
+    
+    def __len__(self):
+        """
+        Return the number of items in the hashtable.
+        """
+        return self.count
+    
+    def pop(self, key, default=None):
+        """
+        Remove specified key and return the value.
+        If key is not found, return default.
+        """
+        bucket = self.hash_function(key)
+        for i, kvpair in enumerate(self.array[bucket]):
+            if kvpair and kvpair[0] == key:
+                value = kvpair[1]
+                del self.array[bucket][i]
+                self.count -= 1
+                return value
+        return default

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -91,3 +91,21 @@ class TestHashTable(unittest.TestCase):
         buckets = self.ht.show_buckets()
         self.assertIn("Bucket", buckets)
         self.assertIn("key7", buckets)
+
+    def test_len(self):
+        ht = HashTable()
+        self.assertEqual(len(ht), 0)
+        ht.set("A", 1)
+        ht.set("B", 2)
+        self.assertEqual(len(ht), 2)
+        ht.delete("A")
+        self.assertEqual(len(ht), 1)
+    
+    def test_pop(self):
+        ht = HashTable()
+        ht.set("A", 1)
+        ht.set("B", 2)
+        self.assertEqual(ht.pop("A"), 1)
+        self.assertEqual(ht.pop("C", "not found"), "not found")
+        self.assertEqual(len(ht), 1)
+        self.assertFalse(ht.key_exists("A"))


### PR DESCRIPTION
This pull request introduces two new methods, `__len__` and `pop`, to the `HashTable` class in `src/dsa/hashtable.py`, along with corresponding unit tests in `tests/test_hash.py`. These changes enhance the functionality of the `HashTable` class by providing a way to retrieve the number of items and remove a key-value pair while handling missing keys gracefully.

### Enhancements to `HashTable` functionality:

* [`src/dsa/hashtable.py`](diffhunk://#diff-1110d34b1022fd3b121aec0d96bb89fcdddbcfe924f6f9e8967517b13a35688aR136-R154): Added the `__len__` method to return the number of items in the hashtable.
* [`src/dsa/hashtable.py`](diffhunk://#diff-1110d34b1022fd3b121aec0d96bb89fcdddbcfe924f6f9e8967517b13a35688aR136-R154): Added the `pop` method to remove a key-value pair by key and return its value, with support for a default value if the key is not found.

### Unit tests for new methods:

* [`tests/test_hash.py`](diffhunk://#diff-3268a5770ad865e35d764eddc8a8327b4854dfab26fc3d5d82199f103ceae705R94-R111): Added `test_len` to verify the behavior of the `__len__` method, including updates after adding and deleting items.
* [`tests/test_hash.py`](diffhunk://#diff-3268a5770ad865e35d764eddc8a8327b4854dfab26fc3d5d82199f103ceae705R94-R111): Added `test_pop` to validate the functionality of the `pop` method, ensuring it correctly removes keys, handles missing keys with a default value, and updates the hashtable state.