### PR TITLE
update linked list delete methods to remove by value

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,15 +1,10 @@
 import os
 import sys
 
-
-import os
-import sys
-sys.path.insert(0, os.path.abspath('..'))
-
-import dsa
-
 # Add the src folder to sys.path so Sphinx can import your package
 sys.path.insert(0, os.path.abspath("../src"))
+
+import dsa
 
 # -- Project information -----------------------------------------------------
 project = "ucxdsa"
@@ -20,19 +15,19 @@ version = dsa.__version__
 # -- General configuration ---------------------------------------------------
 extensions = [
     "sphinx.ext.autodoc",
-    "sphinx.ext.napoleon",       # for Google/NumPy docstrings
-    "sphinx.ext.autosummary",    # generate pages for each class/function
+    "sphinx.ext.napoleon",  # for Google/NumPy docstrings
+    "sphinx.ext.autosummary",  # generate pages for each class/function
     "sphinx_autodoc_typehints",
-    "sphinx.ext.githubpages"
+    "sphinx.ext.githubpages",
 ]
 
-autosummary_generate = True     # generate stub files automatically
+autosummary_generate = True  # generate stub files automatically
 
 # Mock imports to prevent hanging if packages are missing
 autodoc_mock_imports = ["matplotlib", "networkx"]
 
 templates_path = ["_templates"]
-html_static_path = ['_static']
+html_static_path = ["_static"]
 exclude_patterns = []
 
 # -- Options for HTML output -------------------------------------------------

--- a/src/dsa/doublylinkedlist.py
+++ b/src/dsa/doublylinkedlist.py
@@ -1,11 +1,13 @@
-""" Module containing doubly linked list class. """
+"""Module containing doubly linked list class."""
+
 
 class Node:
-    """ 
+    """
     A doubly linked list node implementation.
     """
+
     def __init__(self, value):
-        """ 
+        """
         Args:
             value: The value of the node.
         """
@@ -15,23 +17,27 @@ class Node:
         self.next = None
         #: reference to the previous node
         self.prev = None
-    
+
+
 class DoublyLinkedList:
-    """ 
+    """
     A doubly linked list implementation.
     """
-    def __init__(self, head: Node|None=None, tail: Node|None=None, count: int=0):
-        """ 
+
+    def __init__(
+        self, head: Node | None = None, tail: Node | None = None, count: int = 0
+    ):
+        """
         Initialize a singly linked list.
-        
+
         if only the head node is specified, tail is set to the head node and count is automatically set to 0.
         if both head and tail nodes are specified, count should be specified as well.
-        
+
         Args:
             head (Node): Reference to the head node.
             tail (Node): Reference to the tail node.
             count (int): The number of nodes in the linked list.
-        """        
+        """
         self.head = head
         if head and tail is None:
             self.tail = head
@@ -47,7 +53,7 @@ class DoublyLinkedList:
 
         Args:
             mylist: A list or container to convert from.
-        
+
         Returns:
             Doubly linked list with the contents of the list.
         """
@@ -56,7 +62,7 @@ class DoublyLinkedList:
             dll.append(value)
 
         return dll
-    
+
     def to_list(self) -> list:
         """
         Create a list with contents of the doubly linked list.
@@ -70,7 +76,7 @@ class DoublyLinkedList:
             mylist.append(current.value)
             current = current.next
         return mylist
-        
+
     def __repr__(self):
         """
         Return a string representation of the doubly linked list.
@@ -91,14 +97,14 @@ class DoublyLinkedList:
         return f"[ {s}] Count: {self.count}"
 
     def __getitem__(self, index: int) -> Node:
-        """ 
+        """
         Return value at a specified index. Raise exception if index is out of bounds.
-        
+
         Args:
             index (int): The index of the value.
         Raises:
             IndexError: if index is out of bounds.
-        """        
+        """
         i = 0
         current = self.head
         while current:
@@ -107,13 +113,13 @@ class DoublyLinkedList:
             current = current.next
             i += 1
         raise IndexError("Index Out of Bounds")
-    
+
     def __len__(self) -> int:
         """
         Return the number of elements in the doubly linked list.
         """
         return self.count
-    
+
     def is_empty(self) -> bool:
         """
         Return True if the doubly linked list is empty.
@@ -139,7 +145,7 @@ class DoublyLinkedList:
             print(current.value, end=" ")
             current = current.prev
         print()
-    
+
     def search(self, value) -> int:
         """
         Search for a value in the linked list. Raise exception if value is not found.
@@ -161,7 +167,7 @@ class DoublyLinkedList:
             i += 1
             current = current.next
         raise Exception("Value not found")
-    
+
     def insert(self, index: int, value):
         """
         Insert a value at a specified index. Raise exception if index is out of bounds.
@@ -173,7 +179,7 @@ class DoublyLinkedList:
         Raises:
             IndexError: if index is out of bounds.
         """
-        
+
         # insert front
         if index == 0:
             self.prepend(value)
@@ -183,7 +189,7 @@ class DoublyLinkedList:
             return
         elif index > self.count:
             raise IndexError("Index Out of Bounds")
-        
+
         # find node to insert after
         i = 0
         current = self.head
@@ -203,7 +209,7 @@ class DoublyLinkedList:
         new_node.prev.next = new_node
 
         self.count += 1
-        
+
     def prepend(self, value):
         """
         Place a value at the beginning of the doubly linked list.
@@ -230,66 +236,54 @@ class DoublyLinkedList:
                 self.tail = self.head
             self.count += 1
             return
-        
+
         # go to the end of the list
         new_node = Node(value)
         new_node.prev = self.tail
         self.tail.next = new_node
         self.tail = new_node
-        
-        self.count += 1
-        
 
-    def delete(self, index: int):
+        self.count += 1
+
+    def delete(self, value):
         """
-        Delete a node at a specified index. Raises exception if linked list is empty or if index is invalid.
+        Delete the first occurrence of a value in the doubly linked list.
 
         Args:
-            index (int): The index of element to be deleted.
+            value: The value to be deleted.
 
         Raises:
-            IndexError: If linked list is empty or index is invalid.
+            ValueError: If the value is not found.
         """
         if self.head is None:
-            raise IndexError("DoublyLinkedList is Empty")
+            raise ValueError("Value not found")
 
-        if index == 0: # Special case: Delete the head node
-            self.delete_head()
-            return
-        elif index == self.count - 1:
-            self.delete_tail()
-            return
-        elif index >= self.count:
-            raise IndexError("Index out of range")
-        
-        # Traverse the list to find the node at the specified index
         current = self.head
-        for i in range(index):
-            if current.next is None:
-                raise IndexError("Index out of range")
+        while current:
+            if current.value == value:
+                if current == self.head:
+                    self.delete_head()
+                elif current == self.tail:
+                    self.delete_tail()
+                else:
+                    current.prev.next = current.next
+                    current.next.prev = current.prev
+                    self.count -= 1
+                return
             current = current.next
 
-        # Remove the node by adjusting pointers
-        if current.next:
-            current.next.prev = current.prev
-        else:  # If the node to be deleted is the tail (might be redundant)
-            self.tail = current.prev
-
-        if current.prev:
-            current.prev.next = current.next
-
-        self.count -= 1
+        raise ValueError("Value not found")
 
     def delete_tail(self):
         """
-        Delete the tail node of the doubly linked list. 
+        Delete the tail node of the doubly linked list.
 
         Raises:
             IndexError: If linked list is empty.
         """
         if self.tail is None:
             raise IndexError("DoublyLinkedList is Empty")
-        
+
         self.tail = self.tail.prev
         self.tail.next = None
         self.count -= 1
@@ -322,5 +316,4 @@ class DoublyLinkedList:
         """
         if not isinstance(other, DoublyLinkedList):
             return False
-        return self.to_list() == other.to_list()    
-
+        return self.to_list() == other.to_list()

--- a/src/dsa/singlylinkedlist.py
+++ b/src/dsa/singlylinkedlist.py
@@ -238,41 +238,40 @@ class LinkedList:
         
         self.count += 1
 
-    def delete(self, index: int):
+    def delete(self, value):
         """
-        Delete a node at a specified index. Raise IndexError if linked list is empty or if index is not found.
+        Delete the first occurrence of a value in the linked list.
 
         Args:
-            index: Index of element to be deleted.
+            value: The value to be deleted.
         
         Returns:
             None
             
         Raises:
-            IndexError: If linked list is empty or index is not found.
+            ValueError: If the value is not found.
         """
-        if index == 0:
-            self.delete_head()
-            return
-        elif index + 1 == self.count:
-            self.delete_tail()
+        if self.head is None:
+            raise ValueError("Value not found")
+
+        if self.head.value == value:
+            self.head = self.head.next
+            self.count -= 1
+            if self.count == 0:
+                self.tail = None
             return
 
-        i = 0
         current = self.head
-        prev = None
-        while current:
-            if index == i:
-                if prev is not None:
-                    prev.next = current.next
-                else:
-                    self.head = current.next
+        while current.next:
+            if current.next.value == value:
+                if current.next == self.tail:
+                    self.tail = current
+                current.next = current.next.next
                 self.count -= 1
                 return
-            i += 1
-            prev = current
             current = current.next
-        raise IndexError("Index not found")
+            
+        raise ValueError("Value not found")
 
     def delete_head(self):
         """

--- a/tests/test_doublylinkedlist.py
+++ b/tests/test_doublylinkedlist.py
@@ -1,6 +1,7 @@
 import unittest
 from dsa.doublylinkedlist import DoublyLinkedList, Node
 
+
 class TestDoublyLinkedList(unittest.TestCase):
 
     # --- Initialization Tests ---
@@ -86,24 +87,24 @@ class TestDoublyLinkedList(unittest.TestCase):
         self.verify_prev_links(ll)
 
     # --- Deletion Tests ---
-    def test_delete_at_indices(self):
+    def test_delete_value(self):
         ll = DoublyLinkedList.from_list(range(15))
-        self.assertRaises(IndexError, ll.delete, 15)
-        for _ in range(15):
-            ll.delete(0)
+        self.assertRaises(ValueError, ll.delete, 15)
+
+        for i in range(15):
+            ll.delete(i)
         self.assertEqual(ll.count, 0)
-        self.assertRaises(IndexError, ll.delete, 0)
+        self.assertRaises(ValueError, ll.delete, 0)
 
         ll = DoublyLinkedList.from_list(range(15))
-        for _ in range(15):
-            ll.delete(len(ll) - 1)
+        for i in range(14, -1, -1):
+            ll.delete(i)
         self.assertEqual(ll.count, 0)
         self.verify_prev_links(ll)
 
-        ll = DoublyLinkedList.from_list(range(15))
-        for _ in range(5):
-            ll.delete(len(ll) // 2)
-        self.assertEqual(ll.count, 10)
+        ll = DoublyLinkedList.from_list([1, 2, 3, 4, 5])
+        ll.delete(3)
+        self.assertEqual(ll.to_list(), [1, 2, 4, 5])
         self.verify_prev_links(ll)
 
     def test_delete_head_tail_and_middle(self):
@@ -113,7 +114,7 @@ class TestDoublyLinkedList(unittest.TestCase):
         ll.delete(0)
         self.assertEqual(ll.head.value, 1)
         ll.delete(3)
-        self.assertEqual(ll[3], 5)
+        self.assertEqual(ll[2], 4)
         self.assertEqual(ll.count, 17)
         self.verify_prev_links(ll)
 
@@ -153,7 +154,7 @@ class TestDoublyLinkedList(unittest.TestCase):
             self.assertEqual(node.next.prev, node)
             node = node.next
             self.assertIsNotNone(node.prev, "Malformed list: missing prev link")
-    
+
     def test_eq(self):
         dll1 = DoublyLinkedList.from_list([1, 2, 3, 4])
         dll2 = DoublyLinkedList.from_list([1, 2, 3, 4])
@@ -166,5 +167,6 @@ class TestDoublyLinkedList(unittest.TestCase):
         self.assertNotEqual(dll1, DoublyLinkedList.from_list([1, 2, 3]))
         self.assertNotEqual(dll1, [1, 2, 3, 4])
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_singlylinkedlist.py
+++ b/tests/test_singlylinkedlist.py
@@ -1,6 +1,7 @@
 import unittest
 from dsa.singlylinkedlist import LinkedList, Node
 
+
 class TestLinkedList(unittest.TestCase):
 
     # --- Creation Tests ---
@@ -31,9 +32,7 @@ class TestLinkedList(unittest.TestCase):
 
     # --- Conversion Tests ---
     def test_from_list(self):
-        for values, expected_count in [
-            ([], 0), ([1], 1), ([1, 2], 2), ([1, 2, 3], 3)
-        ]:
+        for values, expected_count in [([], 0), ([1], 1), ([1, 2], 2), ([1, 2, 3], 3)]:
             ll = LinkedList.from_list(values)
             self.assertEqual(ll.count, expected_count)
             if values:
@@ -92,33 +91,33 @@ class TestLinkedList(unittest.TestCase):
         self.assertRaises(IndexError, ll.insert, 20, 300)
 
     # --- Deletion Tests ---
-    def test_delete_index(self):
+    def test_delete_value(self):
         ll = LinkedList()
         for i in range(15):
             ll.append(i)
-        self.assertRaises(IndexError, ll.delete, 15)
+        self.assertRaises(ValueError, ll.delete, 15)
 
         for i in range(15):
-            ll.delete(0)
+            ll.delete(i)
             self.assertEqual(ll.count, 14 - i)
-        self.assertRaises(IndexError, ll.delete, 0)
+        self.assertRaises(ValueError, ll.delete, 0)
 
         for i in range(15):
             ll.append(i)
-        for i in range(15):
-            ll.delete(len(ll) - 1)
-            self.assertEqual(ll.count, 14 - i)
-        self.assertRaises(IndexError, ll.delete, 0)
+        for i in range(14, -1, -1):
+            ll.delete(i)
+            self.assertEqual(ll.count, i)
+        self.assertRaises(ValueError, ll.delete, 0)
 
     def test_delete_middle_and_edges(self):
         ll = LinkedList.from_list(range(15))
-        for i in range(5):
-            ll.delete(len(ll) // 2)
-            self.assertEqual(ll.count, 14 - i)
+        ll.delete(7)
+        self.assertEqual(ll.count, 14)
+        self.assertRaises(ValueError, ll.delete, 7)
 
-        ll.delete(len(ll) - 1)
+        ll.delete(14)
         self.assertEqual(ll.tail.value, 13)
-        self.assertEqual(ll.count, 9)
+        self.assertEqual(ll.count, 13)
 
         ll = LinkedList.from_list(range(20))
         ll.delete(19)
@@ -126,7 +125,7 @@ class TestLinkedList(unittest.TestCase):
         ll.delete(0)
         self.assertEqual(ll.head.value, 1)
         ll.delete(3)
-        self.assertEqual(ll[3], 5)
+        self.assertEqual(ll[2], 4)
         self.assertEqual(ll.count, 17)
 
     def test_delete_head(self):
@@ -177,5 +176,6 @@ class TestLinkedList(unittest.TestCase):
 
         self.assertNotEqual(ll1, [1, 2, 3, 4])
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Linked List Deletion Refactor

* Changed the `delete` method in both `DoublyLinkedList` and `LinkedList` classes to remove the first occurrence of a given value rather than deleting by index. The method now raises a `ValueError` if the value is not found, instead of an `IndexError` for invalid indices.
* Updated all relevant test cases in `test_doublylinkedlist.py` and `test_singlylinkedlist.py` to test value-based deletion, including expected exceptions and edge cases.

### Code and Documentation Consistency
* Implemented **Black** Python formatter to improve formatting and consistency in both implementation and test files, such as spacing, quote usage, and list comprehensions.
* Updated Sphinx documentation to fix the error in the Github Action 