### PR TITLE
add from_dict methods to graph classes

### DIFF
--- a/src/dsa/graph.py
+++ b/src/dsa/graph.py
@@ -57,6 +57,33 @@ class Graph:
         else:
             return AdjacencyListGraph(directed=directed, vertices=vertices)
 
+    @staticmethod
+    def from_dict(data: dict, graph_type: str, directed: bool = False, weighted: bool = False) -> object:
+        """ 
+        Create a graph from a dictionary representation using the factory.
+        
+        Args:
+            data (dict): The dictionary representation of the graph.
+            graph_type (str): The type of graph ('adjacency_matrix' or 'adjacency_list').
+            directed (bool): Whether the graph is directed.
+            weighted (bool): Whether the graph is weighted.
+            
+        Returns:
+            An instance of the specified graph class.
+        """
+        if graph_type == 'adjacency_matrix':
+            if weighted:
+                return AdjacencyMatrixWeightedGraph.from_dict(data, directed=directed)
+            else:
+                return AdjacencyMatrixGraph.from_dict(data, directed=directed)
+        elif graph_type == 'adjacency_list':
+            if weighted:
+                return AdjacencyListWeightedGraph.from_dict(data, directed=directed)
+            else:
+                return AdjacencyListGraph.from_dict(data, directed=directed)
+        else:
+            raise ValueError("Invalid graph type. Use 'adjacency_matrix' or 'adjacency_list'.")
+
 class AdjacencyMatrixGraph:
     """ 
     An unweighted adjacency matrix graph implementation.
@@ -341,6 +368,25 @@ class AdjacencyMatrixGraph:
         
         return matrix_dict
 
+    @classmethod
+    def from_dict(cls, data: dict, directed: bool = False):
+        """ 
+        Create a graph from a dictionary representation.
+        
+        Args:
+            data (dict): The dictionary representation of the graph.
+            directed (bool): Whether the graph is directed.
+            
+        Returns:
+            An instance of the graph class.
+        """
+        vertices = list(data.keys())
+        graph = cls(directed=directed, vertices=vertices)
+        for start_node, neighbors in data.items():
+            for end_node in neighbors:
+                graph.add_edge(start_node, end_node)
+        return graph
+
 class AdjacencyMatrixWeightedGraph(AdjacencyMatrixGraph):
     """ 
     A weighted adjacency matrix graph implementation
@@ -464,6 +510,25 @@ class AdjacencyMatrixWeightedGraph(AdjacencyMatrixGraph):
         """
         index = self.label_index[vertex]
         return {self.labels[i] : self._matrix[index][i] for i in range(len(self._matrix[index])) if self._matrix[index][i]}
+
+    @classmethod
+    def from_dict(cls, data: dict, directed: bool = False):
+        """ 
+        Create a weighted graph from a dictionary representation.
+        
+        Args:
+            data (dict): The dictionary representation of the graph.
+            directed (bool): Whether the graph is directed.
+            
+        Returns:
+            An instance of the weighted graph class.
+        """
+        vertices = list(data.keys())
+        graph = cls(directed=directed, vertices=vertices)
+        for start_node, neighbors in data.items():
+            for end_node, weight in neighbors.items():
+                graph.add_edge(start_node, end_node, weight)
+        return graph
 
 class AdjacencyListGraph:
     """ 
@@ -698,6 +763,25 @@ class AdjacencyListGraph:
         """
         return {key: values.copy() for key, values in self._adjacents.items()}
     
+    @classmethod
+    def from_dict(cls, data: dict, directed: bool = False):
+        """ 
+        Create a graph from a dictionary representation.
+        
+        Args:
+            data (dict): The dictionary representation of the graph.
+            directed (bool): Whether the graph is directed.
+            
+        Returns:
+            An instance of the graph class.
+        """
+        vertices = list(data.keys())
+        graph = cls(directed=directed, vertices=vertices)
+        for start_node, neighbors in data.items():
+            for end_node in neighbors:
+                graph.add_edge(start_node, end_node)
+        return graph
+    
 class AdjacencyListWeightedGraph(AdjacencyListGraph):
     """ 
     A weighted adjacency list vertex implementation in Python
@@ -837,4 +921,23 @@ class AdjacencyListWeightedGraph(AdjacencyListGraph):
                 if start != end and (end, start, weight) not in edges:  
                     edges.append((start, end, weight))
         return edges
+
+    @classmethod
+    def from_dict(cls, data: dict, directed: bool = False):
+        """ 
+        Create a weighted graph from a dictionary representation.
+        
+        Args:
+            data (dict): The dictionary representation of the graph.
+            directed (bool): Whether the graph is directed.
+            
+        Returns:
+            An instance of the weighted graph class.
+        """
+        vertices = list(data.keys())
+        graph = cls(directed=directed, vertices=vertices)
+        for start_node, neighbors in data.items():
+            for end_node, weight in neighbors.items():
+                graph.add_edge(start_node, end_node, weight)
+        return graph
 

--- a/tests/test_graph_adjacency_list.py
+++ b/tests/test_graph_adjacency_list.py
@@ -89,6 +89,32 @@ class TestAdjacencyListGraph(unittest.TestCase):
         # Edge List
         self.assertSetEqual(set(g.edges()), {('A', 'B'), ('B', 'C'), ('C', 'D'), ('D', 'E'), ('E', 'A')})
 
+    def test_from_dict(self):
+        # Unweighted
+        data = {
+            'A': ['B', 'C'],
+            'B': ['A', 'C', 'D'],
+            'C': ['A', 'B', 'D'],
+            'D': ['B', 'C', 'E'],
+            'E': ['D', 'F'],
+            'F': ['E', 'G'],
+            'G': ['F']
+        }
+        g = AdjacencyListGraph.from_dict(data, directed=False)
+        self.assertEqual(g.to_dict(), data)
+        self.assertEqual(g.order(), 7)
+        self.assertEqual(g.size(), 8)
+
+        # Weighted
+        data_weighted = {
+            'A': {'B': 1, 'C': 2},
+            'B': {'A': 1, 'C': 3},
+            'C': {'A': 2, 'B': 3}
+        }
+        g_weighted = AdjacencyListWeightedGraph.from_dict(data_weighted, directed=False)
+        self.assertEqual(g_weighted.to_dict(), data_weighted)
+        self.assertEqual(g_weighted.order(), 3)
+        self.assertEqual(g_weighted.size(), 3)
 
     ## 4. MUTATION TESTS
 

--- a/tests/test_graph_adjacency_matrix.py
+++ b/tests/test_graph_adjacency_matrix.py
@@ -89,6 +89,32 @@ class TestAdjacencyMatrixGraph(unittest.TestCase):
         # Edge List
         self.assertSetEqual(set(g.edges()), {('A', 'B'), ('B', 'C'), ('C', 'D'), ('D', 'E'), ('E', 'A')})
 
+    def test_from_dict(self):
+        # Unweighted
+        data = {
+            'A': ['B', 'C'],
+            'B': ['A', 'C', 'D'],
+            'C': ['A', 'B', 'D'],
+            'D': ['B', 'C', 'E'],
+            'E': ['D', 'F'],
+            'F': ['E', 'G'],
+            'G': ['F']
+        }
+        g = AdjacencyMatrixGraph.from_dict(data, directed=False)
+        self.assertEqual(g.to_dict(), data)
+        self.assertEqual(g.order(), 7)
+        self.assertEqual(g.size(), 8)
+
+        # Weighted
+        data_weighted = {
+            'A': {'B': 1, 'C': 2},
+            'B': {'A': 1, 'C': 3},
+            'C': {'A': 2, 'B': 3}
+        }
+        g_weighted = AdjacencyMatrixWeightedGraph.from_dict(data_weighted, directed=False)
+        self.assertEqual(g_weighted.to_dict(), data_weighted)
+        self.assertEqual(g_weighted.order(), 3)
+        self.assertEqual(g_weighted.size(), 3)
 
     ## 4. MUTATION TESTS
 

--- a/tests/test_graph_factory.py
+++ b/tests/test_graph_factory.py
@@ -48,6 +48,17 @@ class TestGraphFactory(unittest.TestCase):
         
         with self.assertRaises(ValueError):
             Graph.create(graph_type='unknown_type')
+
+    def test_graph_from_dict(self):
+        data = {'A': ['B'], 'B': ['A']}
+        g = Graph.from_dict(data, graph_type='adjacency_list', directed=False, weighted=False)
+        self.assertIsInstance(g, AdjacencyListGraph)
+        self.assertEqual(g.to_dict(), data)
+
+        data_weighted = {'A': {'B': 1}, 'B': {'A': 1}}
+        g_weighted = Graph.from_dict(data_weighted, graph_type='adjacency_matrix', directed=False, weighted=True)
+        self.assertIsInstance(g_weighted, AdjacencyMatrixWeightedGraph)
+        self.assertEqual(g_weighted.to_dict(), data_weighted)
             
 class TestAdjacencyListGraph(unittest.TestCase):
     def test_create_undirected(self):


### PR DESCRIPTION
Added support for creating all graph types from dictionary representations, with tests for all graph types.

**Core functionality:**

* Added `from_dict` class methods to `AdjacencyMatrixGraph`, `AdjacencyMatrixWeightedGraph`, `AdjacencyListGraph`, and `AdjacencyListWeightedGraph`, allowing instantiation of graphs from dictionary representations. 
* Added a static `from_dict` method in the `Graph` factory class to create any graph type from a dictionary, based on the specified `graph_type`, `directed`, and `weighted` parameters.