### PR TITLE
Trie pretty print updates

### DIFF
--- a/src/dsa/draw.py
+++ b/src/dsa/draw.py
@@ -284,6 +284,9 @@ class TrieDraw(Draw):
         Returns:
             dict: A dictionary mapping each node to its (x, y) position in the layout.
         """
+        if G.number_of_nodes() == 0:
+            return {}
+
         if root is None:
             root = next(iter(nx.topological_sort(G)))
     

--- a/src/dsa/pretty_print.py
+++ b/src/dsa/pretty_print.py
@@ -118,3 +118,58 @@ def tree_print(tree):
     complete_tree = fill_complete_tree(tree)
     if complete_tree:
         _array_print(len(complete_tree), enumerate(complete_tree))
+
+
+def trie_print(trie):
+    """
+    Print a trie from root to leaves.
+
+    Args:
+        trie: The trie object to print.
+    """
+    trie_lines = trie_to_array(trie)
+    if trie_lines:
+        for line in trie_lines:
+            print(line)
+        print()
+
+
+def trie_to_array(trie):
+    """
+    (helper function) Create an array of display lines from a trie.
+
+    Args:
+        trie: The trie to convert.
+
+    Returns:
+        Array of strings for trie display.
+    """
+    if trie is None or trie.root is None or len(trie.root.children) == 0:
+        return None
+
+    trie_array = ["•"]
+    end_marker = getattr(trie, "end_marker", "*")
+    _build_trie_lines(trie.root, "", trie_array, end_marker)
+    return trie_array
+
+
+def _build_trie_lines(node, prefix, trie_array, end_marker):
+    """
+    (helper function) Recursively append trie display lines.
+    """
+    children = []
+    for key, child in sorted(node.children.items()):
+        if key != end_marker:
+            children.append((key, child))
+
+    for index, pair in enumerate(children):
+        char = pair[0]
+        child = pair[1]
+        is_last = index == len(children) - 1
+
+        connector = "└── " if is_last else "├── "
+        suffix = end_marker if end_marker in child.children else ""
+        trie_array.append(f"{prefix}{connector}{char}{suffix}")
+
+        next_prefix = prefix + ("    " if is_last else "│   ")
+        _build_trie_lines(child, next_prefix, trie_array, end_marker)

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -120,6 +120,12 @@ class TestDraw(unittest.TestCase):
         td.set_figsize((12, 4))
         td.save('images/trie.png')
 
+    def test_trie_empty(self):
+        t = Trie()
+        td = TrieDraw(t)
+        td.set_figsize((12, 4))
+        td.save('images/trie_empty.png')
+
     def test_graph(self):
         graph = AdjacencyMatrixGraph(["A", "B", "C", "D"])
         graph.add_edge("A", "B")

--- a/tests/test_pretty_print.py
+++ b/tests/test_pretty_print.py
@@ -2,7 +2,8 @@ import unittest
 
 from dsa.tree import Tree
 from dsa.heap import Heap
-from dsa.pretty_print import heap_print, tree_print
+from dsa.trie import Trie
+from dsa.pretty_print import heap_print, tree_print, trie_print
 
 class TestPrettyPrint(unittest.TestCase):
     def test_tree(self):
@@ -41,3 +42,16 @@ class TestPrettyPrint(unittest.TestCase):
 
         h.insert(35)
         heap_print(h)
+
+    def test_trie(self):
+        t = Trie()
+        trie_print(t)
+
+        t.insert("app")
+        trie_print(t)
+
+        t.insert("apple")
+        trie_print(t)
+
+        t.insert("bat")
+        trie_print(t)


### PR DESCRIPTION
**Trie pretty-printing support:**

* Added a new `trie_print` function and its helpers (`trie_to_array`, `_build_trie_lines`) in `src/dsa/pretty_print.py` to visualize trie structures in a readable format.

**Graph and trie visualization robustness:**

* Improved `hierarchical_pos` in `src/dsa/draw.py` to return an empty dictionary if the input graph has no nodes, preventing errors on empty input.
* Added a test for drawing an empty trie in `tests/test_draw.py` to ensure the visualization handles empty structures gracefully.